### PR TITLE
Add busy-signal

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -43,6 +43,33 @@ class ScalametaLanguageClient extends AutoLanguageClient {
     const match = filePath.match(/\.(semanticdb|compilerconfig)$/i);
     return (match != null);
   }
+
+  consumeBusySignal(busySignalService) {
+    this.busySignal = busySignalService;
+  }
+
+  busyMessageFormat(text) {
+    return `${this.getServerName()}: ${text}`;
+  }
+
+  updateBusyMessage(text = '', init = false, reveal = false) {
+    if (this.busyMessage != null) {
+      if (text === '') {
+        this.busyMessage.dispose();
+        this.busyMessage = null;
+      } else {
+        this.busyMessage.setTitle(
+          this.busyMessageFormat(text),
+          { revealTooltip: reveal }
+        );
+      }
+    } else if (init) {
+      this.busyMessage = this.busySignal.reportBusy(
+        this.busyMessageFormat(text),
+        { revealTooltip: reveal }
+      );
+    }
+  }
 }
 
 module.exports = new ScalametaLanguageClient();

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,7 +5,7 @@ const cp = require('child_process');
 class ScalametaLanguageClient extends AutoLanguageClient {
   getGrammarScopes () { return [ 'source.scala' ] }
   getLanguageName () { return 'Scala' }
-  getServerName () { return 'scalameta' }
+  getServerName () { return 'Scalameta' }
 
   startServerProcess (projectPath) {
     const javaHome = cp.execSync('/usr/libexec/java_home').toString().trim();
@@ -42,6 +42,14 @@ class ScalametaLanguageClient extends AutoLanguageClient {
   filterChangeWatchedFiles (filePath) {
     const match = filePath.match(/\.(semanticdb|compilerconfig)$/i);
     return (match != null);
+  }
+
+  preInitialization(connection) {
+    this.updateBusyMessage('initializing server', true, true);
+  }
+
+  postInitialization (server) {
+    this.updateBusyMessage();
   }
 
   consumeBusySignal(busySignalService) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
       "versions": {
         "0.1.0": "consumeDatatip"
       }
+    },
+    "atom-ide-busy-signal": {
+      "versions": {
+        "0.1.0": "consumeBusySignal"
+      }
     }
   },
   "providedServices": {


### PR DESCRIPTION
Server initialization may take up to 9s, so it'd be useful to show a spinning busy-singal while waiting for the server response. Formatting should support it out of the box.