### PR TITLE
Normalize the package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ide-scala",
   "main": "./lib/main",
   "version": "0.2.0",
-  "description": "Scala language support for Atom-IDE.",
+  "description": "Scala language support for Atom-IDE",
   "author": {
     "name": "Alexey Alekhin",
     "email": "laughedelic@gmail.com",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ide-scala",
   "main": "./lib/main",
   "version": "0.2.0",
-  "description": "Scala language support for Atom IDE using Scalameta language server",
+  "description": "Scala language support for Atom-IDE.",
   "author": {
     "name": "Alexey Alekhin",
     "email": "laughedelic@gmail.com",


### PR DESCRIPTION
To be consistent with other IDE packages such as `ide-typescript` or `ide-python`.

The fact that the `ide-scala` package uses `scalameta` is an implementation detail, which should rather be stated in the README than in the description.