### PR TITLE
Download coursier on the first run

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,5 +47,6 @@ libraryDependencies ++= Seq(
   "laughedelic" %%% "scalajs-atom-api" % "0.1.0"
 )
 
+// Following atom packages convention: lib/main.js is the plugin's entry point
 artifactPath in (Compile, fullOptJS) := baseDirectory.value / "lib" / "main.js"
 artifactPath in (Compile, fastOptJS) := (artifactPath in (Compile, fullOptJS)).value

--- a/src/main/scala/ScalaLanguageClient.scala
+++ b/src/main/scala/ScalaLanguageClient.scala
@@ -20,8 +20,10 @@ class ScalaLanguageClient extends AutoLanguageClient { client =>
     val javaHome = ChildProcess.asInstanceOf[js.Dynamic].execSync("/usr/libexec/java_home").toString.trim
     val toolsJar = Path.join(javaHome, "lib", "tools.jar")
 
-    // TODO: try to use coursier directly or download it on the first run
-    val coursierJar = Path.join(OS.homedir, "bin", "coursier")
+    val packagePath = global.atom.packages
+      .getLoadedPackage("ide-scala")
+      .path.asInstanceOf[String]
+    val coursierJar = Path.join(packagePath, "coursier")
 
     val javaBin = Path.join(javaHome, "bin", "java")
     val javaArgs =


### PR DESCRIPTION
- atom-language client kindly provides some utils for this: https://github.com/atom/atom-languageclient/blob/master/lib/download-file.js
- examples:
  * [ide-java](https://github.com/atom/ide-java/blob/master/lib/main.js#L173-L186) (with status bar updating)
  * [ide-php](https://github.com/atom/ide-java/blob/master/lib/main.js#L173-L186) (with busy-signal updating)

It could be also useful to check if user has coursier already installed and just use it.