### PR TITLE
Fix failing CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: scala
 jdk: oraclejdk8
 scala: 2.12.4
 
+git:
+  depth: false
+
 stages:
   - name: test
 


### PR DESCRIPTION
I figured out that CI fails because I modified how the sbt-dynver version is set. It needs tags which are not accessible because Travis makes a shallow git clone.