### PR TITLE
Add support for the logging console

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ resolvers += Resolver.bintrayRepo("laughedelic", "maven")
 
 libraryDependencies ++= Seq(
   "io.scalajs" %%% "nodejs" % "0.4.2",
-  "laughedelic" %%% "scalajs-atom-api" % "0.6.0+3-0d95f37f",
+  "laughedelic" %%% "scalajs-atom-api" % "0.6.0+5-c464d2a3",
   "laughedelic" %%% "scalajs-java-home" % "0.1.0"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ apmKeywords := Seq(
 apmEngines := Map("atom" -> ">=1.21.0 <2.0.0")
 
 apmDependencies := Map(
-  "atom-languageclient" -> "0.8.3",
+  "atom-languageclient" -> "0.9.4",
   "atom-package-deps" -> "4.6.1",
   "find-java-home" -> "0.2.0"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,8 @@ apmConsumedServices := Map(
   "linter-indie"          -> Map("2.0.0" -> "consumeLinterV2"),
   "datatip"               -> Map("0.1.0" -> "consumeDatatip"),
   "atom-ide-busy-signal"  -> Map("0.1.0" -> "consumeBusySignal"),
-  "signature-help"        -> Map("0.1.0" -> "consumeSignatureHelp")
+  "signature-help"        -> Map("0.1.0" -> "consumeSignatureHelp"),
+  "console"               -> Map("0.1.0" -> "consumeConsole"),
 )
 
 apmProvidedServices := Map(

--- a/src/main/scala/Exports.scala
+++ b/src/main/scala/Exports.scala
@@ -45,5 +45,7 @@ object Exports {
   def consumeBusySignal(service: BusySignalService): Unit = client.consumeBusySignal(service)
   @JSExportTopLevel("consumeSignatureHelp")
   def consumeSignatureHelp(registry: js.Any): js.Any = client.consumeSignatureHelp(registry)
+  @JSExportTopLevel("consumeConsole")
+  def consumeConsole(service: js.Any): js.Any = client.asInstanceOf[js.Dynamic].consumeConsole(service)
 
 }

--- a/src/main/scala/Exports.scala
+++ b/src/main/scala/Exports.scala
@@ -46,6 +46,6 @@ object Exports {
   @JSExportTopLevel("consumeSignatureHelp")
   def consumeSignatureHelp(registry: js.Any): js.Any = client.consumeSignatureHelp(registry)
   @JSExportTopLevel("consumeConsole")
-  def consumeConsole(service: js.Any): js.Any = client.asInstanceOf[js.Dynamic].consumeConsole(service)
+  def consumeConsole(service: js.Any): js.Any = client.consumeConsole(service)
 
 }

--- a/src/main/scala/ScalaLanguageClient.scala
+++ b/src/main/scala/ScalaLanguageClient.scala
@@ -80,22 +80,6 @@ class ScalaLanguageClient extends AutoLanguageClient { client =>
     serverProcess
   }
 
-  override def preInitialization(connection: LanguageClientConnection): Unit = {
-    // NOTE: a workaround for repeating notifications (it should be fixed in atom-notifications)
-    // On every new notification it goes through all matching old notifications and dismisses them.
-    // We can do it only after the fact. Also we cannot dismiss the new one instead, because if some
-    // old ones were dismissed manually, user won't see the new notifications.
-    Atom.notifications.onDidAddNotification { newOne =>
-      val notifications = Atom.notifications.getNotifications()
-      val matching = notifications.filter { oldOne =>
-        oldOne != newOne &&
-        oldOne.getType() == newOne.getType() &&
-        oldOne.getMessage() == newOne.getMessage()
-      }
-      matching.foreach { _.dismiss() }
-    }
-  }
-
   override def postInitialization(server: ActiveServer): Unit = {
     val serverSupportedCommands = server.capabilities.executeCommandProvider.map(_.commands.toSet).getOrElse(Set.empty)
 


### PR DESCRIPTION
This adds support for the logging console implemented in https://github.com/atom/atom-languageclient/pull/192:

<img width="752" alt="screen shot 2018-03-16 at 04 31 44" src="https://user-images.githubusercontent.com/766656/37502452-15f7f7ba-28d3-11e8-8998-15e673508b7d.png">

This also removes the notifications hack (added in #22), it was fixed in https://github.com/atom/atom-languageclient/pull/177.