### PR TITLE
Delayed activation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,6 +101,9 @@ apmJsonExtra := Json.obj(
   "package-deps" -> Json.arr(
     "language-scala",
     "atom-ide-ui"
+  ),
+  "activationHooks" -> Json.arr(
+    "language-scala:grammar-used"
   )
 )
 


### PR DESCRIPTION
From [the docs](https://flight-manual.atom.io/hacking-atom/sections/package-word-count/#packagejson):

> `activationHooks`: an `Array` of `Strings` identifying hooks that trigger your package's activation. The loading of your package is delayed until one of these hooks are triggered. **Currently, there are two activation hooks**: `language-package-name:grammar-used` (e.g., `language-javascript:grammar-used`) and `core:loaded-shell-environment`.

Not many options, but better than nothing. I'm adding a hook to delay package activation until the first Scala file is opened. This should lessen the impact on Atom startup time. 