### PR TITLE
Add version setting for each server instead of one common

### DIFF
--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -23,11 +23,6 @@ object Config extends ConfigSchema {
       }.toJSArray,
   )
 
-  val serverVersion = new Setting[String](
-    title = "Language server version",
-    default = ScalaLanguageServer.none.defaultVersion,
-  )
-
   val java = new SettingsGroup(JavaConfig,
     title = "Java configuration",
     collapsed = true,
@@ -38,19 +33,16 @@ object Config extends ConfigSchema {
     collapsed = true,
   )
 
-  override def postInit(): Unit = {
-    // This toggles server version depending on the chosen server type
-    defaultServer.onDidChange({ change: SettingChange[String] =>
-      for {
-        oldValue <- change.oldValue
-        oldST <- ScalaLanguageServer.fromName(oldValue)
-          // NOTE: if the version is changed, we don't want to overwrite it
-          if oldST.defaultVersion == Config.serverVersion.get
-        newST <- ScalaLanguageServer.fromName(change.newValue)
-      } yield
-        Config.serverVersion.set(newST.defaultVersion)
-    })
-  }
+  val dotty = new SettingsGroup(DottyConfig,
+    title = "Dotty configuration",
+    collapsed = true,
+  )
+
+  val ensime = new SettingsGroup(EnsimeConfig,
+    title = "Ensime configuration",
+    collapsed = true,
+  )
+
 }
 
 object JavaConfig extends ConfigSchema {

--- a/src/main/scala/ScalaLanguageClient.scala
+++ b/src/main/scala/ScalaLanguageClient.scala
@@ -118,8 +118,8 @@ class ScalaLanguageClient extends AutoLanguageClient { client =>
         // `name` field is set early and then used in some UI elements (instead of
         // `getServerName`), we can update it here to fix, for example, logger console
         client.asInstanceOf[js.Dynamic]
-          .updateDynamic("name")(chosen.name.capitalize)
-        chosen.launch(projectPath)
+          .updateDynamic("name")(server.name.capitalize)
+        server.launch(projectPath)
     }.toJSPromise
   }
 

--- a/src/main/scala/ScalaLanguageServer.scala
+++ b/src/main/scala/ScalaLanguageServer.scala
@@ -1,15 +1,13 @@
 package laughedelic.atom.ide.scala
 
 import scala.scalajs.js, js.JSConverters._
-import io.scalajs.nodejs.child_process.{ ChildProcess, SpawnOptions, ExecOptions }
+import io.scalajs.nodejs.child_process.{ ChildProcess, SpawnOptions }
 import laughedelic.atom.languageclient.ActiveServer
 
 trait ScalaLanguageServer {
   val name: String
   val description: String
   val defaultVersion: String
-
-  def version: String = Config.serverVersion.get
 
   def trigger(projectPath: String): Boolean
   def watchFilter(filePath: String): Boolean

--- a/src/main/scala/servers/Dotty.scala
+++ b/src/main/scala/servers/Dotty.scala
@@ -1,5 +1,6 @@
 package laughedelic.atom.ide.scala
 
+import laughedelic.atom.config._
 import scala.util.Try
 
 object Dotty extends ScalaLanguageServer {
@@ -20,7 +21,7 @@ object Dotty extends ScalaLanguageServer {
     val artifactRef = Try {
       (projectPath / artifactFile).readSync().trim
     } getOrElse {
-      s"ch.epfl.lamp:dotty-language-server_0.7:${Config.serverVersion.get}"
+      s"ch.epfl.lamp:dotty-language-server_0.7:${Config.dotty.version.get}"
     }
     Seq(
       artifactRef,
@@ -30,4 +31,13 @@ object Dotty extends ScalaLanguageServer {
   }
 
   val commands = Map()
+}
+
+object DottyConfig extends ConfigSchema {
+
+  val version = new Setting[String](
+    title = "Dotty version",
+    description = "This version will be used only if `.dotty-ide-artifact` is missing",
+    default = Dotty.defaultVersion,
+  )
 }

--- a/src/main/scala/servers/Ensime.scala
+++ b/src/main/scala/servers/Ensime.scala
@@ -1,5 +1,7 @@
 package laughedelic.atom.ide.scala
 
+import laughedelic.atom.config._
+
 object Ensime extends ScalaLanguageServer {
   val name: String = "ensime"
   val description: String = "Ensime (broken!)"
@@ -28,10 +30,18 @@ object Ensime extends ScalaLanguageServer {
   def coursierArgs(projectPath: String): Seq[String] = Seq(
     "--repository", "bintray:dhpcs/maven",
     "--repository", "sonatype:snapshots",
-    s"org.ensime:server_2.12:${Config.serverVersion.get}",
+    s"org.ensime:server_2.12:${Config.ensime.version.get}",
     "--main", "org.ensime.server.Server",
     "--", "--lsp"
   )
 
   val commands = Map()
+}
+
+object EnsimeConfig extends ConfigSchema {
+
+  val version = new Setting[String](
+    title = "Ensime version",
+    default = Ensime.defaultVersion,
+  )
 }

--- a/src/main/scala/servers/Metals.scala
+++ b/src/main/scala/servers/Metals.scala
@@ -8,7 +8,7 @@ import laughedelic.atom.languageclient.{ ActiveServer, ExecuteCommandParams }
 object Metals extends ScalaLanguageServer { server =>
   val name: String = "metals"
   val description: String = "Metals"
-  val defaultVersion: String = "e1b3a1fa"
+  val defaultVersion: String = "0.1.0-M1+90-fcac1cc3"
 
   def trigger(projectPath: String): Boolean = {
     (projectPath / ".metals").isDirectory
@@ -22,7 +22,7 @@ object Metals extends ScalaLanguageServer { server =>
 
   def coursierArgs(projectPath: String): Seq[String] = Seq(
     "--repository", "bintray:scalameta/maven",
-    s"org.scalameta:metals_2.12:${Config.serverVersion.get}",
+    s"org.scalameta:metals_2.12:${Config.metals.version.get}",
     "--main", "scala.meta.metals.Main"
   )
 
@@ -41,6 +41,12 @@ object Metals extends ScalaLanguageServer { server =>
 }
 
 object MetalsConfig extends ConfigSchema {
+
+  val version = new Setting[String](
+    title = "Metals version",
+    description = "Set it to `SNAPSHOT` if you're working on Metals and publish it locally",
+    default = Metals.defaultVersion,
+  )
 
   val hover = new SettingsGroup(Hover, "Tooltips on hover")
   object Hover extends ConfigSchema {


### PR DESCRIPTION
This should fix #60. Instead of setting default server version, now you can set version for each server, so if you have automatic server selection enabled, you still can run custom server versions in different projects.