### PR TITLE
Add command to restart all servers associated with the client

### DIFF
--- a/src/main/scala/ScalaLanguageClient.scala
+++ b/src/main/scala/ScalaLanguageClient.scala
@@ -134,7 +134,7 @@ class ScalaLanguageClient extends AutoLanguageClient { client =>
       .foreach { cmd =>
         server.commands.get(cmd).foreach { handler =>
           Atom.commands.add(
-            "atom-text-editor",
+            "atom-workspace",
             s"${server.name}:${camelToKebab(cmd)}",
             { node =>
               handler(activeServer)(node)
@@ -142,6 +142,14 @@ class ScalaLanguageClient extends AutoLanguageClient { client =>
           )
         }
       }
+
+    Atom.commands.add(
+      "atom-workspace",
+      s"ide-scala:restart-all-language-servers",
+      { _ =>
+        client.restartAllServers()
+      }: js.Function1[js.Any, Unit]
+    )
   }
 
   override def getRootConfigurationKey(): String =


### PR DESCRIPTION
This fixes #55. Although it doesn't work as I expected, it's a simple solution.

The problem is that if I have several projects open in the same workspace, they are still managed by the same client and therefore the command will be associated with all of them. 

A general restart-all-servers command is fine for testing new locally published server snapshots without reloading Atom window every time. A per-project server restart can be added later and will require some changes in atom-languageclient (currently `_serverManager` is private).