### PR TITLE
New Metals

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Scala & Dotty support for [Atom IDE], powered by [Metals], [Dotty] and [Ensime] 
 
 ![](https://user-images.githubusercontent.com/766656/34135911-aa78092a-e463-11e7-9fdf-710a8deb4093.png)
 
+(The screenshot above is outdated, the set of features depends on the language server you're going to use)
+
 #### 🚧 WORK IN PROGRESS 🚧
 
 The project is in active development and may have some rough edges. You are welcome to try it out and provide any feedback in the [Gitter chat](https://gitter.im/laughedelic/atom-ide-scala) or [Github issues](https://github.com/laughedelic/atom-ide-scala/issues).
@@ -23,45 +25,9 @@ During development some reusable parts were split into separate repos:
 * [scalajs-atom-api](https://github.com/laughedelic/scalajs-atom-api): Scala.js facades for Atom-related APIs (including atom-languageclient)
 * [sbt-atom-package](https://github.com/laughedelic/sbt-atom-package): an sbt plugin wraping apm and simplifying development of Scala.js-based Atom plugins
 
-## Features
-
-<details><summary> ⚠️ This list is outdated and refers only to the Metals features. Check each supported server documentation to find out which features they support.</summary>
-
-Here is a list of the features which are implemented. It doesn't mean that they all work well, just that they are implemented on the server side and are supported by this plugin. Also notice that some features may take time to activate after you open a new file or change code.
-
-* [Formatting](https://github.com/facebook-atom/atom-ide-ui/blob/master/docs/code-format.md) with [Scalafmt](http://scalameta.org/scalafmt):
-  + Add `.scalafmt` [config](http://scalameta.org/scalafmt/#Configuration) to the project
-  + Use <kbd>Cmd</kbd><kbd>Shift</kbd><kbd>C</kbd> hotkey
-  + It formats the whole file
-* [Diagnostics](https://github.com/facebook-atom/atom-ide-ui/blob/master/docs/diagnostics.md) (linting with [Scalafix](https://scalacenter.github.io/scalafix) and presentation compiler):
-  + If you have `.scalafix` configuration in the project, you will see linting messages in the diagnostics panel and red underlines in the code
-  + You will also see compilation errors from the presentation compiler as you type
-* [Definitions](https://github.com/facebook-atom/atom-ide-ui/blob/master/docs/definitions.md):
-  + Hold <kbd>Cmd</kbd> and hover to preview the definition or click to jump to the source
-* [References](https://github.com/facebook-atom/atom-ide-ui/blob/master/docs/find-references.md):
-  + Right-click on a symbol and choose `Find References` in the context menu
-  + Or open command palette and run `Find References` command
-* [Code Highlights](https://github.com/facebook-atom/atom-ide-ui/blob/master/docs/code-highlight.md):
-  + When cursor is placed on a symbol, all its occurrences in the file should get highlighted
-* [Datatips](https://github.com/facebook-atom/atom-ide-ui/blob/master/docs/datatips.md) (type on hover):
-  + Just hover over a symbol to see its type
-  + You can also hold <kbd>Alt</kbd> to see the type of symbol under the cursor
-* [Outline view](https://github.com/facebook-atom/atom-ide-ui/blob/master/docs/outline-view.md) (symbols tree):
-  + Use <kbd>Alt</kbd><kbd>O</kbd> to open it
-* Auto completions as you type with presentation compiler
-  + This is experimental and requires some extra setup
-* [Signature Help](https://github.com/facebook-atom/atom-ide-ui/blob/master/docs/signature-help.md) (experimental UI):
-  + When you type a method name and an open parenthesis you should see information about method parameters
-
-See also default [Atom IDE keybindings](https://github.com/facebook-atom/atom-ide-ui/blob/master/docs/keybindings.md).
-
-For the full list of implemented and planned features see the [overview](https://github.com/scalameta/metals/blob/master/docs/overview.md) of the Metals project.
-
-</details>
-
 ## Installation
 
-You can install it by following [this link](atom://settings-view/show-package?package=ide-scala) or by running this command:
+Open the [package page](https://atom.io/packages/ide-scala) and click the green _Install_ button. Or run this command:
 
 ```
 apm install ide-scala
@@ -73,37 +39,29 @@ On the first launch it will automatically install its dependencies if needed:
 
 ## Usage
 
-This plugin can work with different Scala language servers. You can use it for Scala-2.12 Metals projects as well as for the Dotty projects.
-
-In any case it is expected that you first follow the corresponding language server setup instructions to prepare your project. Usually it involves installing an sbt plugin and running some setup command for every new project. The Atom plugin will check the project setup and choose the right server automatically. This is configurable:
-
-* you can select a default server which will be used for all new projects (you're still expected to setup your projects manually until servers can do it on their own)
-* you can turn off automatic server choice if you always want to use same server
+This plugin can work with different Scala language servers: Metals for Scala 2 projects or Dotty for Scala 3 projects. The plugin tries to determine which server to launch depending on the project setup.
 
 Plugin gets activated only when you open a `.scala` file.
 
 > ⚠️ Notice that when you close all tabs with Scala files, language server will be stopped. See [atom-languageclient#141](https://github.com/atom/atom-languageclient/issues/141) for discussion on this behavior.
 
-### Metals
+### [Metals]
 
-1. Follow Metals [installation instructions](https://scalameta.org/metals/docs/installation-contributors.html) to prepare a project.
-1. Open this project in Atom. Once you open a Scala file, you will see the server launching.
+Metals project setup is completely automatic: when you open a new project, it will ask you if you want to import the build definition. If something goes wrong or doesn't work as expected, run Metals Doctor through the command palette.
 
-### Dotty
+More details on the [Metals website](https://scalameta.org/metals/docs/editors/atom.html).
 
-1. Setup a [Dotty sbt project](https://github.com/lampepfl/dotty-example-project) and run `sbt configureIDE` in it.  
-    Official instructions may tell you to run `launchIDE` in sbt, but this command can only launch VS Code, so just use `configureIDE` instead and open the project in Atom.
-1. Open this project in Atom. Once you open a Scala file, you will see the server launching.
+### [Dotty]
 
-### Ensime
+Setup a [Dotty sbt project](https://github.com/lampepfl/dotty-example-project) and run `sbt configureIDE` in it, then just open the project in Atom.
 
-🚧 Ensime support is very much experimental, because the LSP implementation of the Ensime server is quite unstable at the moment. So even if the client works well, the server might be broken and you won't see any features working. 🚧
+Official instructions may tell you to run `launchIDE` in sbt, but this command can only launch VS Code, so just use `configureIDE` instead and open the project in Atom.
 
-1. Follow [Ensime documentation](http://ensime.github.io/getting_started/) to generate an `.ensime` project file.
-1. Open this project in Atom. Once you open a Scala file, the server will start (bu you may not notice it).
-1. Open the developer console (<kbd>Cmd</kbd><kbd>Alt</kbd><kbd>I</kbd>) and observe the logs (most likely errors).
+### [Ensime]
 
-Follow [ensime-server#1935](https://github.com/ensime/ensime-server/issues/1935) for more information and _get involved if you want to use Ensime LSP server_.
+🚧 Ensime support is removed for now because the LSP implementation of the Ensime server is quite unstable at the moment and Ensime is not actively maintained. So even if the client works well, the server might be broken and you won't see any features working. 🚧
+
+Follow [ensime-server#1951](https://github.com/ensime/ensime-server/pull/1951) for more information and _get involved if you want to use Ensime LSP server_.
 
 
 [Scala]: http://scala-lang.org/

--- a/build.sbt
+++ b/build.sbt
@@ -88,6 +88,7 @@ apmConsumedServices := Map(
   "atom-ide-busy-signal"  -> Map("0.1.0" -> "consumeBusySignal"),
   "signature-help"        -> Map("0.1.0" -> "consumeSignatureHelp"),
   "console"               -> Map("0.1.0" -> "consumeConsole"),
+  "status-bar"            -> Map("^1.0.0" -> "consumeStatusBar"),
 )
 
 apmProvidedServices := Map(

--- a/build.sbt
+++ b/build.sbt
@@ -80,6 +80,7 @@ apmDependencies := Map(
   "atom-package-deps" -> "4.6.2",
   "@atom/source-map-support" -> "0.3.4",
   "s-expression" -> "3.0.3",
+  "minimatch" -> "3.0.4",
 )
 
 apmConsumedServices := Map(

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ developers := List(Developer(
   url("https://github.com/laughedelic")
 ))
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.7"
 scalacOptions ++= Seq(
   "-encoding", "utf8",
   "-feature",
@@ -73,11 +73,11 @@ apmKeywords := Seq(
   "ensime",
 )
 
-apmEngines := Map("atom" -> ">=1.21.0 <2.0.0")
+apmEngines := Map("atom" -> ">=1.25.0 <2.0.0")
 
 apmDependencies := Map(
-  "atom-languageclient" -> "0.9.5",
-  "atom-package-deps" -> "4.6.1",
+  "atom-languageclient" -> "0.9.8",
+  "atom-package-deps" -> "4.6.2",
   "@atom/source-map-support" -> "0.3.4",
   "s-expression" -> "3.0.3",
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.2.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.1.0")
 addSbtPlugin("ohnosequences" % "sbt-github-release" % "0.7.0")
 addSbtPlugin("laughedelic" % "sbt-atom-package" % "0.1.2")

--- a/src/main/scala/AtomPackage.scala
+++ b/src/main/scala/AtomPackage.scala
@@ -2,6 +2,7 @@ package laughedelic.atom.ide.scala
 
 import scala.scalajs.js, js.annotation._, js.Dynamic.global
 import laughedelic.atom.ide.ui.busysignal.BusySignalService
+import laughedelic.atom.ide.ui.statusbar.StatusBarView
 import laughedelic.atom.packagedeps.packageDeps
 
 @js.native @JSImport("@atom/source-map-support", JSImport.Namespace)
@@ -64,5 +65,7 @@ object AtomPackage {
   def consumeSignatureHelp(registry: js.Any): js.Any = client.consumeSignatureHelp(registry)
   @JSExportTopLevel("consumeConsole")
   def consumeConsole(service: js.Any): js.Any = client.consumeConsole(service)
+  @JSExportTopLevel("consumeStatusBar")
+  def consumeStatusBar(statusBar: StatusBarView): Unit = client.consumeStatusBar(statusBar)
 
 }

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -7,20 +7,17 @@ object Config extends ConfigSchema {
 
   val autoServer = new Setting[Boolean](
     title = "Choose server based on the project setup",
-    description = "Read the usage section below to learn how to setup projects",
+    description = "If you once used a language server in the project, it will be used there every time you open it again",
     default = true,
   )
 
   val defaultServer = new Setting[String](
     title = "Default language server",
-    description = "This server will be used when project setup is ambiguous or the above option is off",
-    default = Metals.name,
-    enum = (
-        ScalaLanguageServer.none +:
-        ScalaLanguageServer.values
-      ).map { s =>
-        new AllowedValue(s.name, s.description)
-      }.toJSArray,
+    description = "This server will be used in new projects or when the above option is off",
+    default = ScalaLanguageServer.default.name,
+    enum = ScalaLanguageServer.values.map { s =>
+      new AllowedValue(s.name, s.description)
+    }.toJSArray,
   )
 
   val metals = new SettingsGroup(MetalsConfig,
@@ -30,11 +27,6 @@ object Config extends ConfigSchema {
 
   val dotty = new SettingsGroup(DottyConfig,
     title = "Dotty configuration",
-    collapsed = true,
-  )
-
-  val ensime = new SettingsGroup(EnsimeConfig,
-    title = "Ensime configuration",
     collapsed = true,
   )
 

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -14,7 +14,7 @@ object Config extends ConfigSchema {
   val defaultServer = new Setting[String](
     title = "Default language server",
     description = "This server will be used when project setup is ambiguous or the above option is off",
-    default = ScalaLanguageServer.none.name,
+    default = Metals.name,
     enum = (
         ScalaLanguageServer.none +:
         ScalaLanguageServer.values

--- a/src/main/scala/ScalaLanguageClient.scala
+++ b/src/main/scala/ScalaLanguageClient.scala
@@ -24,17 +24,6 @@ class ScalaLanguageClient extends AutoLanguageClient { client =>
     div.classList.add("inline-block")
     div
   }
-  private val statusIcon: Element = {
-    val icon = dom.document.createElement("span")
-    icon.classList.add("icon")
-    statusElement.appendChild(icon)
-    icon
-  }
-  private val statusText: Element = {
-    val text = dom.document.createElement("span")
-    statusElement.appendChild(text)
-    text
-  }
 
 
   private def chooseServer(projectPath: String): Future[ScalaLanguageServer] = {
@@ -155,7 +144,7 @@ class ScalaLanguageClient extends AutoLanguageClient { client =>
         server.commands.get(cmd).foreach { handler =>
           Atom.commands.add(
             "atom-workspace",
-            s"${server.name}:${camelToKebab(cmd)}",
+            s"${server.name}:${cmd}",
             { node =>
               handler(activeServer)(node)
             }: js.Function1[js.Any, Unit]
@@ -175,21 +164,7 @@ class ScalaLanguageClient extends AutoLanguageClient { client =>
       .connection
       .asInstanceOf[js.Dynamic]
       .onCustom("metals/status", { params: js.Dynamic =>
-        // Remove the old icon, if there is any
-        if (client.statusIcon.classList.length > 1) {
-          val old = client.statusIcon.classList.item(1)
-          client.statusIcon.classList.remove(old);
-        }
-        // Add new icon if there is $(name) in the text
-        val newText = raw"\$$\(([a-z]+)\)".r.replaceAllIn(
-          params.text.toString,
-          { mtch =>
-            val name = mtch.group(1)
-            client.statusIcon.classList.add(s"icon-${name}")
-            ""
-          }
-        )
-        client.statusText.textContent = newText
+        client.statusElement.innerHTML = params.text.toString
       })
 
     Atom.workspace.onDidChangeActiveTextEditor { editorOrUndef =>

--- a/src/main/scala/ScalaLanguageClient.scala
+++ b/src/main/scala/ScalaLanguageClient.scala
@@ -33,27 +33,10 @@ class ScalaLanguageClient extends AutoLanguageClient { client =>
       else Nil
 
     triggerred match {
-      case Nil if !Config.autoServer.get && !ScalaLanguageServer.defaultNonEmpty => {
-        Atom.notifications.addError(
-          "No Scala language server is selected",
-          new NotificationOptions(
-            description = "Automatic server selection is off and no default is chosen. Go to the [ide-scala settings](atom://settings-view/show-package?package=ide-scala) to fix it.",
-            detail = projectPath,
-            dismissable = true,
-            icon = "mute",
-          )
-        )
-        Future(ScalaLanguageServer.none)
-      }
-
       case Nil => {
         val default = ScalaLanguageServer.fromConfig
-        val title = "Project is not setup" ++ {
-          if (default == ScalaLanguageServer.none) " for any Scala language server"
-          else s", using default language server: **${default.name.capitalize}**"
-        }
-        Atom.notifications.addWarning(
-          title,
+        Atom.notifications.addInfo(
+          "Project is not setup, using default language server: **${default.name.capitalize}**",
           new NotificationOptions(
             description = "To learn how to setup new projects, follow the [documentation](https://github.com/laughedelic/atom-ide-scala#usage)",
             detail = projectPath,
@@ -119,10 +102,7 @@ class ScalaLanguageClient extends AutoLanguageClient { client =>
   override def startServerProcess(
     projectPath: String
   ): ChildProcess | js.Promise[ChildProcess] = {
-    chooseServer(projectPath).map {
-      case ScalaLanguageServer.none =>
-        throw new RuntimeException("Couldn't start server: project is not setup and default server is not chosen")
-      case chosen =>
+    chooseServer(projectPath).map { chosen =>
         server = chosen
         // `name` field is set early and then used in some UI elements (instead of
         // `getServerName`), we can update it here to fix, for example, logger console

--- a/src/main/scala/ScalaLanguageClient.scala
+++ b/src/main/scala/ScalaLanguageClient.scala
@@ -150,6 +150,20 @@ class ScalaLanguageClient extends AutoLanguageClient { client =>
         client.restartAllServers()
       }: js.Function1[js.Any, Unit]
     )
+
+    Atom.workspace.onDidChangeActiveTextEditor { editorOrUndef =>
+      for {
+        editor <- editorOrUndef
+        if client.shouldStartForEditor(editor)
+        uri <- editor.getURI
+      } yield {
+        val fileUri = new java.net.URI("file", "", uri, null)
+        activeServer
+          .connection
+          .asInstanceOf[js.Dynamic]
+          .sendCustomNotification("metals/didFocusTextDocument", fileUri.toString)
+      }
+    }
   }
 
   override def getRootConfigurationKey(): String =

--- a/src/main/scala/ScalaLanguageServer.scala
+++ b/src/main/scala/ScalaLanguageServer.scala
@@ -31,6 +31,11 @@ trait ScalaLanguageServer {
   }
 
   val commands: Map[String, ActiveServer => js.Any => Any]
+
+  def postInitialization(
+    client: ScalaLanguageClient,
+    activeServer: ActiveServer
+  ): Unit = {}
 }
 
 object ScalaLanguageServer {

--- a/src/main/scala/ScalaLanguageServer.scala
+++ b/src/main/scala/ScalaLanguageServer.scala
@@ -40,6 +40,8 @@ trait ScalaLanguageServer {
 
 object ScalaLanguageServer {
 
+  val default = Metals
+
   def fromName(name: String): Option[ScalaLanguageServer] =
     name match {
       case Metals.name | "scalameta" => Some(Metals)
@@ -49,25 +51,10 @@ object ScalaLanguageServer {
     }
 
   def fromConfig: ScalaLanguageServer =
-    fromName(Config.defaultServer.get).getOrElse(none)
+    fromName(Config.defaultServer.get).getOrElse(default)
 
   def defaultNonEmpty: Boolean =
     fromName(Config.defaultServer.get).nonEmpty
 
-  val values = List(Metals, Dotty, Ensime)
-
-  // An empty server which can be used to initialize the client, before the
-  // config is accessible or projet setup can be determined
-  object none extends ScalaLanguageServer {
-    val name: String = ""
-    val description: String = "none"
-    val defaultVersion: String = ""
-    def trigger(projectPath: String): Boolean = false
-    def watchFilter(filePath: String): Boolean = false
-    def coursierArgs(projectPath: String): Seq[String] = Seq()
-    val commands = Map()
-
-    // FIXME: should do exactly nothing
-    // override def launch(projectPath: String): ChildProcess = ???
-  }
+  val values = List(Metals, Dotty)
 }

--- a/src/main/scala/StatusBar.scala
+++ b/src/main/scala/StatusBar.scala
@@ -1,0 +1,47 @@
+/** This is a facade for the official status bar plugin:
+  * https://github.com/atom/status-bar
+  */
+package laughedelic.atom.ide.ui.statusbar
+
+import scala.scalajs.js, js.|
+import org.scalajs.dom.raw.Element
+
+class StatusTileOptions(
+  val item: Element | js.Object,
+  val priority: js.UndefOr[Int] = js.undefined,
+) extends js.Object
+
+@js.native
+trait StatusTile extends js.Object {
+
+  /** Retrieve the Tile's item. */
+  def getItem(): Element | js.Object
+
+  /** Retrieve the priority that was assigned to the Tile when it was created. */
+  def getPriority(): Int
+
+  /** Remove the Tile from the status bar. */
+  def destroy(): Unit
+}
+
+@js.native
+trait StatusBarView extends js.Object {
+
+  /** Add a tile to the left side of the status bar. Lower priority tiles are
+    * placed further to the left.
+    */
+  def addLeftTile(options: StatusTileOptions): StatusTile
+
+  /** Add a tile to the right side of the status bar. Lower priority tiles are
+    * placed further to the right.
+    */
+  def addRightTile(options: StatusTileOptions): StatusTile
+
+  /** Retrieve all of the tiles on the left side of the status bar. */
+  def getLeftTiles(): js.Array[StatusTile]
+
+  /** Retrieve all of the tiles on the right side of the status bar. */
+  def getRightTiles(): js.Array[StatusTile]
+
+  def destroy(): Unit = js.native
+}

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -1,5 +1,8 @@
 package laughedelic.atom.ide
 
+import _root_.scala.scalajs.js
+import laughedelic.atom.Atom
+import org.scalajs.dom.raw.Element
 import io.scalajs.nodejs.path.Path
 import io.scalajs.nodejs.fs.Fs
 import util.Try
@@ -18,5 +21,10 @@ package object scala {
     def readSync(): Try[String] = Try {
       Fs.readFileSync(path).toString("utf-8")
     }
+  }
+
+  def dispatchAtomCommand(command: String): Unit = {
+    val target = Atom.asInstanceOf[js.Dynamic].views.getView(Atom.workspace).asInstanceOf[Element]
+    Atom.commands.dispatch(target, command)
   }
 }

--- a/src/main/scala/servers/Ensime.scala
+++ b/src/main/scala/servers/Ensime.scala
@@ -39,7 +39,7 @@ object Ensime extends ScalaLanguageServer {
         "-classpath", dotEnsime.classpath.mkString(Path.delimiter),
         s"-Densime.config=${projectPath / ensimeFile}", // saw it somewhere, not sure it's needed
         s"-Dlsp.workspace=${projectPath}",
-        s"-Dlsp.logLevel=${Config.ensime.logLevel.get}",
+        // s"-Dlsp.logLevel=${Config.ensime.logLevel.get}", // ensime config is removed for now
         "org.ensime.server.Server", "--lsp"
       )
     println((javaBin +: javaArgs).mkString("\n"))

--- a/src/main/scala/servers/Metals.scala
+++ b/src/main/scala/servers/Metals.scala
@@ -1,8 +1,13 @@
 package laughedelic.atom.ide.scala
 
-import scala.scalajs.js
+import scala.scalajs.js, js.annotation._
 import laughedelic.atom.config._
 import laughedelic.atom.languageclient.{ ActiveServer, ExecuteCommandParams }
+
+@js.native @JSImport("minimatch", JSImport.Default)
+object minimatch extends js.Object {
+  def apply(path: String, pattern: String): Boolean = js.native
+}
 
 object Metals extends ScalaLanguageServer { server =>
   val name: String = "metals"
@@ -13,7 +18,10 @@ object Metals extends ScalaLanguageServer { server =>
     (projectPath / ".metals").isDirectory
   }
 
-  def watchFilter(filePath: String): Boolean = false
+  def watchFilter(filePath: String): Boolean = {
+    minimatch(filePath, "**/*.{scala,sbt,java}") ||
+    minimatch(filePath, "**/project/build.properties")
+  }
 
   override def javaExtraArgs(projectPath: String): Seq[String] =
     Config.metals.javaArgs.get.toSeq ++ Seq(

--- a/src/main/scala/servers/Metals.scala
+++ b/src/main/scala/servers/Metals.scala
@@ -27,7 +27,7 @@ class HtmlView(title: String, html: String) extends js.Object {
 object Metals extends ScalaLanguageServer { server =>
   val name: String = "metals"
   val description: String = "Metals"
-  val defaultVersion: String = "0.2.3-SNAPSHOT"
+  val defaultVersion: String = "0.2.5"
 
   def trigger(projectPath: String): Boolean = {
     (projectPath / ".metals").isDirectory

--- a/src/main/scala/servers/Metals.scala
+++ b/src/main/scala/servers/Metals.scala
@@ -16,8 +16,10 @@ object Metals extends ScalaLanguageServer { server =>
   def watchFilter(filePath: String): Boolean = false
 
   override def javaExtraArgs(projectPath: String): Seq[String] =
-    Config.metals.javaArgs.get.toSeq :+
-    "-Dmetals.extensions=true"
+    Config.metals.javaArgs.get.toSeq ++ Seq(
+      "-Dmetals.extensions=true",
+      "-Dmetals.icons=octicons",
+    )
 
   def coursierArgs(projectPath: String): Seq[String] = Seq(
     s"org.scalameta:metals_2.12:${Config.metals.version.get}",

--- a/src/main/scala/servers/Metals.scala
+++ b/src/main/scala/servers/Metals.scala
@@ -16,7 +16,8 @@ object Metals extends ScalaLanguageServer { server =>
   def watchFilter(filePath: String): Boolean = false
 
   override def javaExtraArgs(projectPath: String): Seq[String] =
-    Config.metals.javaArgs.get.toSeq
+    Config.metals.javaArgs.get.toSeq :+
+    "-Dmetals.extensions=true"
 
   def coursierArgs(projectPath: String): Seq[String] = Seq(
     s"org.scalameta:metals_2.12:${Config.metals.version.get}",

--- a/src/main/scala/servers/Metals.scala
+++ b/src/main/scala/servers/Metals.scala
@@ -1,39 +1,32 @@
 package laughedelic.atom.ide.scala
 
 import scala.scalajs.js
-import laughedelic.atom.{ Atom, NotificationOptions }
 import laughedelic.atom.config._
 import laughedelic.atom.languageclient.{ ActiveServer, ExecuteCommandParams }
 
 object Metals extends ScalaLanguageServer { server =>
   val name: String = "metals"
   val description: String = "Metals"
-  val defaultVersion: String = "0.1.0-M1+90-fcac1cc3"
+  val defaultVersion: String = "SNAPSHOT"
 
   def trigger(projectPath: String): Boolean = {
     (projectPath / ".metals").isDirectory
   }
 
-  def watchFilter(filePath: String): Boolean = {
-    filePath.endsWith(".semanticdb") ||
-    filePath.endsWith(".properties") ||
-    filePath.endsWith("active.json")
-  }
+  def watchFilter(filePath: String): Boolean = false
 
   override def javaExtraArgs(projectPath: String): Seq[String] =
     Config.metals.javaArgs.get.toSeq
 
   def coursierArgs(projectPath: String): Seq[String] = Seq(
-    "--repository", "bintray:scalameta/maven",
     s"org.scalameta:metals_2.12:${Config.metals.version.get}",
     "--main", "scala.meta.metals.Main"
   )
 
   val commands = Seq(
-    "clearIndexCache",
-    "resetPresentationCompiler",
-    "sbtConnect",
-    // "scalafixUnusedImports",
+    "build.import",
+    "build-server.connect",
+    "workspace.sources.scan",
   ).map { cmd =>
     cmd -> { activeServer: ActiveServer => _: js.Any =>
       activeServer.connection.executeCommand(
@@ -57,141 +50,10 @@ object MetalsConfig extends ConfigSchema {
     default = js.Array(
       "-XX:+UseG1GC",
       "-XX:+UseStringDeduplication",
+      "-Xss4m",
+      "-Xms1G",
+      "-Xmx4G",
     )
   )
 
-  // The rest is the server configuration sent over to Metals
-  val hover = new SettingsGroup(Hover, "Tooltips on hover")
-  object Hover extends ConfigSchema {
-    val enabled = new Setting[Boolean](
-      default = true,
-      title = "Enable tooltips on hover",
-    )
-  }
-
-  val highlight = new SettingsGroup(Highlight, "Symbol highlights")
-  object Highlight extends ConfigSchema {
-    val enabled = new Setting[Boolean](
-      default = false,
-      title = "Enable symbol highlights",
-      description = "⚠️ EXPERIMENTAL: not stable (may misbehave when editing sources)",
-    )
-  }
-
-  val sbt = new SettingsGroup(Sbt, "sbt server integration")
-  object Sbt extends ConfigSchema {
-    val diagnostics = new SettingsGroup(Diagnostics, "Diagnostics on save")
-    object Diagnostics extends ConfigSchema {
-      val enabled = new Setting[Boolean](
-        default = true,
-        title = "Enable diagnostics from the sbt server",
-        description = "Requires sbt v1.1+ (launch it manually)",
-      )
-    }
-    val command = new Setting[String](
-      default = "",
-      title = "sbt command to run on file save"
-    )
-  }
-
-  val scalac = new SettingsGroup(Scalac, "Presentation compiler")
-  object Scalac extends ConfigSchema {
-    val completions = new SettingsGroup(Completions, "Completions as you type")
-    object Completions extends ConfigSchema {
-      val enabled = new Setting[Boolean](
-        default = false,
-        title = "Enable completions with the Scala Presentation Compiler",
-        description = "⚠️ EXPERIMENTAL: not stable (use _Reset Presentation Compiler_ command when it stops working)",
-      )
-    }
-    val diagnostics = new SettingsGroup(Diagnostics, "Diagnostics as you type")
-    object Diagnostics extends ConfigSchema {
-      val enabled = new Setting[Boolean](
-        default = false,
-        title = "Enable diagnostics with the Scala Presentation Compiler",
-        description = "⚠️ EXPERIMENTAL: not stable (use _Reset Presentation Compiler_ command when it stops working)",
-      )
-    }
-  }
-
-  val scalafix = new SettingsGroup(Scalafix, "Code linting with Scalafix")
-  object Scalafix extends ConfigSchema {
-    val enabled = new Setting[Boolean](
-      default = true,
-      title = "Enable Scalafix diagnostics (if configuration file is present)",
-    )
-    val confPath = new Setting[String](
-      default = ".scalafix.conf",
-      title = "Path to the Scalafix configuration, relative to the workspace path"
-    )
-  }
-
-  val scalafmt = new SettingsGroup(Scalafmt, "Code formatting with Scalafmt")
-  object Scalafmt extends ConfigSchema {
-    val enabled = new Setting[Boolean](
-      default = true,
-      title = "Enable formatting with Scalafmt (if configuration file is present)",
-    )
-    val onSave = new Setting[Boolean](
-      default = false,
-      title = "Format file before saving it",
-      description = "⚠️ EXPERIMENTAL: Atom feature in development",
-    )
-    val version = new Setting[String](
-      default = "1.4.0",
-      title = "Version of Scalafmt to use"
-    )
-    val confPath = new Setting[String](
-      default = ".scalafmt.conf",
-      title =
-        "Path to the Scalafmt configuration, relative to the workspace path"
-    )
-  }
-
-  val search = new SettingsGroup(Search, "Symbols search index")
-  object Search extends ConfigSchema {
-    val indexClasspath = new Setting[Boolean](
-      default = true,
-      title = "Enable indexing of the classpath"
-    )
-    val indexJDK = new Setting[Boolean](
-      default = true,
-      title = "Enable indexing of the JDK"
-    )
-  }
-
-  // TODO: uncomment when it's supported in Atom IDE
-  // val rename = new SettingsGroup(Rename, "Renaming symbols")
-  // object Rename extends ConfigSchema {
-  //   val enabled = new Setting[Boolean](
-  //     default = true,
-  //     title = "Enable renaming symbols",
-  //     description = "⚠️ EXPERIMENTAL: not supported in Atom yet",
-  //   )
-  // }
-
-  override def postInit(): Unit = {
-    scalafmt.onSave.onDidChange { change =>
-      if (change.newValue == true) {
-        val ideUiOnSaveRaw =
-          Atom.config.get("atom-ide-ui.atom-ide-code-format.formatOnSave")
-        val ideUiOnSave = js.defined(
-            ideUiOnSaveRaw.asInstanceOf[Boolean]
-          ).getOrElse(false)
-
-        if (ideUiOnSave == true) {
-          Atom.notifications.addWarning(
-            "Scalafmt on Save coflicts with general Format on Save",
-            new NotificationOptions(
-              dismissable = true,
-              description = "General **Format on Save** setting is already enabled. If you want to enable **Scalafmt on Save**, first disable **Format on Save** in the Atom IDE UI settings."
-              // TODO: Link to atom://settings-view/show-package?package=atom-ide-ui (now it doesn't work in notifications)
-            )
-          )
-          // TODO: Unset it. This doesn't work for some reason:
-          // scalafmt.onSave.set(false)
-        }
-      }
-    }
-  }
 }

--- a/src/main/scala/servers/Metals.scala
+++ b/src/main/scala/servers/Metals.scala
@@ -7,7 +7,7 @@ import laughedelic.atom.languageclient.{ ActiveServer, ExecuteCommandParams }
 object Metals extends ScalaLanguageServer { server =>
   val name: String = "metals"
   val description: String = "Metals"
-  val defaultVersion: String = "0.2.1"
+  val defaultVersion: String = "0.2.0-SNAPSHOT"
 
   def trigger(projectPath: String): Boolean = {
     (projectPath / ".metals").isDirectory
@@ -21,7 +21,7 @@ object Metals extends ScalaLanguageServer { server =>
       "-Dmetals.status-bar=on",
       "-Dmetals.file-watcher=custom",
       "-Dmetals.extensions=true",
-      "-Dmetals.icons=octicons",
+      "-Dmetals.icons=atom",
     )
 
   def coursierArgs(projectPath: String): Seq[String] = Seq(

--- a/src/main/scala/servers/Metals.scala
+++ b/src/main/scala/servers/Metals.scala
@@ -7,7 +7,7 @@ import laughedelic.atom.languageclient.{ ActiveServer, ExecuteCommandParams }
 object Metals extends ScalaLanguageServer { server =>
   val name: String = "metals"
   val description: String = "Metals"
-  val defaultVersion: String = "SNAPSHOT"
+  val defaultVersion: String = "0.2.0"
 
   def trigger(projectPath: String): Boolean = {
     (projectPath / ".metals").isDirectory

--- a/src/main/scala/servers/Metals.scala
+++ b/src/main/scala/servers/Metals.scala
@@ -13,7 +13,7 @@ object minimatch extends js.Object {
 object Metals extends ScalaLanguageServer { server =>
   val name: String = "metals"
   val description: String = "Metals"
-  val defaultVersion: String = "0.2.0-SNAPSHOT"
+  val defaultVersion: String = "0.2.3-SNAPSHOT"
 
   def trigger(projectPath: String): Boolean = {
     (projectPath / ".metals").isDirectory
@@ -81,7 +81,6 @@ object MetalsConfig extends ConfigSchema {
   // These are custom settings for the Metals launcher
   val version = new Setting[String](
     title = "Metals version",
-    description = "Set it to `SNAPSHOT` if you're working on Metals and publish it locally",
     default = Metals.defaultVersion,
   )
 


### PR DESCRIPTION
This is targeting Metals v0.2.0. Metals integration just works™, but there are still some warts on the Atom side of this integration.

Metals LSP extensions:
- [x] `metals/didFocus`
- [x] `metals/status`: shows messages in the status bar
- [ ] `metals/slowTask`: cannot implement it, because atom-languageclient currently doesn't allow to add custom request handlers (only notifications). I will fix it upstream, but IMO it would be nice if Metals was a bit more flexible on this and could (as an option) send a normal `showMessageRequest` with a cancel button and no ticking timer.

Other things to do before merging it:
- [x] #56 use glob patterns for file watching filter
- [ ] try to show `metals/status` in the busy-signal and see if it looks better
- [x] improve initialization (server choice): simplify it and probably just set Metals as default (now that it starts quickly and nicely offers to import), and remove the `none` server (which is a hack and always causes problems).